### PR TITLE
Prefetch pages by madvise(2) to prevent random accesses from threads.

### DIFF
--- a/include/PartialCsvParser.hpp
+++ b/include/PartialCsvParser.hpp
@@ -219,6 +219,9 @@ public:
     csv_size = _filesize(fd);
     if ((csv_text = static_cast<const char *>(mmap(NULL, csv_size, PROT_READ, MAP_PRIVATE, fd, 0))) == (void*)-1)
       STRERROR_THROW(PCPError, std::string("while mmap ") + filepath);
+    // prefetch pages from disk to avoid random accesses from threads.
+    if (madvise((void*)csv_text, csv_size, MADV_WILLNEED) == -1)
+      STRERROR_THROW(PCPError, std::string("while madvise ") + filepath);
 
     // parse first line to calculate n_columns
     const char * line = 0;


### PR DESCRIPTION
When page cache is cleared, it did not scale at all even on SSD machine.
The SSD's random access speed is 75MB/sec, while HDD has almost the same random access speed.

I guessed it was because physical disk pages were fetched randomly.
After inserted madvise(2), although 1-thread peformance has slightly decreased, it has scaled pretty better.
