### PR TITLE
Feature/parse from memory

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = PartialCsvParser
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         =
+PROJECT_NUMBER         = 0.1.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ This parser is meant to be created to **parse a CSV file in parallel**.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
-- [PartialCsvParser](#partialcsvparser)
-  - [Features](#features)
-  - [Examples](#examples)
-    - [Simplest example: Parse and print a CSV file](#simplest-example-parse-and-print-a-csv-file)
-    - [Multi-thread example: Parses a CSV file in parallel](#multi-thread-example-parses-a-csv-file-in-parallel)
-  - [Anti-features](#anti-features)
-  - [Reference manual](#reference-manual)
-  - [Parser behaviors](#parser-behaviors)
-    - [All lines of CSV file are parsed exactly once](#all-lines-of-csv-file-are-parsed-exactly-once)
-  - [For developers](#for-developers)
-    - [How to run test cases](#how-to-run-test-cases)
+- [Installation](#installation)
+- [Features](#features)
+- [Examples](#examples)
+  - [Simplest example: Parse and print a CSV file](#simplest-example-parse-and-print-a-csv-file)
+  - [More examples](#more-examples)
+- [Anti-features](#anti-features)
+- [Reference manual](#reference-manual)
+- [Parser behaviors](#parser-behaviors)
+  - [All lines of CSV file are parsed exactly once](#all-lines-of-csv-file-are-parsed-exactly-once)
+- [For developers](#for-developers)
+  - [How to run test cases](#how-to-run-test-cases)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ This parser is meant to be created to **parse a CSV file in parallel**.
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
+## Installation
+
+PartialCsvParser is a **Single-header library** distributed under public domain.
+
+Just copy [PartialCsvParser.hpp](./include/PartialCsvParser.hpp) into your include path and include it.
+You can also `git add` the header file to your repository, and even modify it.
+
+I appreciate your pull requests if you make some improvements :)
+
+
 ## Features
 
 - Pretty good single-thread & multi-thread performance.
@@ -33,11 +43,6 @@ This parser is meant to be created to **parse a CSV file in parallel**.
 
       ![Comparison of CSV parser's performance](https://docs.google.com/spreadsheets/d/1ZqmajL9r4aXAvk_7rp3j7KdLWN71-IbWhVtxB6HpSw4/pubchart?oid=1550764323&format=image)
       ![Scalability on clokoap100](https://docs.google.com/spreadsheets/d/1ZqmajL9r4aXAvk_7rp3j7KdLWN71-IbWhVtxB6HpSw4/pubchart?oid=1943811886&format=image)
-
-- **Single-header library**.
-    - Just copy [PartialCsvParser.hpp](./include/PartialCsvParser.hpp) into your project and include it.
-    - You can freely add the header file to your repository, and even modify it.
-        - I appreciate your pull requests if you make some improvements :)
 
 - Simple interface working with STL (Standard Template Library).
 
@@ -117,90 +122,11 @@ Got a row: Scotland     Punk IPA        IPA
 Got a row: Germany      Franziskaner    Hefe-Weissbier
 ```
 
-### Multi-thread example: Parses a CSV file in parallel
+### More examples
 
-[example/01_parse_with_2parsers_threaded.cpp](./example/01_parse_with_2parsers_threaded.cpp)
-
-```c++
-/**
- * Parses a CSV file and print the contents using 2 threads.
- * Don't care if the output is mixed!
- */
-
-#include <PartialCsvParser.hpp>
-#include <vector>
-#include <string>
-#include <iostream>
-#include <pthread.h>
-
-void * partial_parse(PCP::partial_csv_t * partial_csv) {
-  // instantiate parser
-  PCP::PartialCsvParser parser(partial_csv->csv_config, partial_csv->parse_from, partial_csv->parse_to);
-
-  // parse & print body lines
-  std::vector<std::string> row;
-  while (!(row = parser.get_row()).empty()) {
-    std::cout << "[thread#" << pthread_self() << "] "<< "Got a row: ";
-    for (size_t i = 0; i < row.size(); ++i)
-      std::cout << row[i] << "\t";
-    std::cout << std::endl;
-  }
-  return NULL;
-}
-
-int main() {
-  PCP::CsvConfig csv_config("english.csv");
-
-  // parse header line
-  std::vector<std::string> headers = csv_config.get_headers();
-  // print headers
-  std::cout << "Headers:" << std::endl;
-  for (size_t i = 0; i < headers.size(); ++i)
-    std::cout << headers[i] << "\t";
-  std::cout << std::endl << std::endl;
-
-  // Setup range each thread parse.
-  // One thread parses the former part of CSV, the other parses latter.
-  size_t half_offset = (csv_config.filesize() - csv_config.body_offset()) / 2;
-  PCP::partial_csv_t partial_csv1 = { csv_config, csv_config.body_offset(), half_offset };
-  PCP::partial_csv_t partial_csv2 = { csv_config, half_offset + 1, csv_config.filesize() - 1 };
-
-  // create threads, join them.
-  pthread_t th1, th2;
-  pthread_create(&th1, NULL, (void *(*)(void *))partial_parse, &partial_csv1);
-  pthread_create(&th2, NULL, (void *(*)(void *))partial_parse, &partial_csv2);
-  pthread_join(th1, NULL);
-  pthread_join(th2, NULL);
-
-  return 0;
-}
-```
-
-Lucky output:
-
-```
-$ ./01_parse_with_2parsers_threaded
-Headers:
-Country Name    Style
-
-[thread#0x104fb5000] Got a row: Japan   Shonan Gold     Fruit Beer
-[thread#0x105038000] Got a row: Scotland        Punk IPA        IPA
-[thread#0x105038000] Got a row: Germany Franziskaner    Hefe-Weissbier
-```
-
-Unlucky output:
-
-```
-$ ./01_parse_with_2parsers_threaded
-Headers:
-Country Name    Style
-
-[thread#[thread#0x01x0140a433000] Got a ro9wb:0 0S0c0o]t lGaontd        aP row: Japan   Shonan Gold     Fruit Beer
-unk IPA IPA
-[thread#0x104a33000] Got a row: Germany Franziskaner    Hefe-Weissbier
-```
-
-Since `partial_parse()` invocations are not ordered, printed result may be such a mess.
+- [Parses a CSV file in parallel](./example/01_parse_with_2parsers_threaded.cpp)
+- [TSV from memory](./example/03_parse_tsv_from_memory.cpp)
+- [UTF-8 CSV file](./example/02_parse_utf8.cpp)
 
 
 ## Anti-features

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,3 +1,23 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
+
+- [PartialCsvParser benchmark](#partialcsvparser-benchmark)
+  - [Evaluation settings](#evaluation-settings)
+    - [MBA](#mba)
+    - [clokoap100](#clokoap100)
+    - [Tips: How to check read speed](#tips-how-to-check-read-speed)
+    - [Tips: Memory file system on Mac OSX](#tips-memory-file-system-on-mac-osx)
+  - [Benchmark results](#benchmark-results)
+    - [Comparison with othre libraries](#comparison-with-othre-libraries)
+    - [Scalability](#scalability)
+  - [Generate benchmark data](#generate-benchmark-data)
+  - [Build benchmark executables](#build-benchmark-executables)
+  - [Run PartialCsvParser benchmark](#run-partialcsvparser-benchmark)
+  - [Run csv-parser-cplusplus benchmark](#run-csv-parser-cplusplus-benchmark)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # PartialCsvParser benchmark
 
 Following benchmarks are taken.

--- a/example/03_parse_tsv_from_memory.cpp
+++ b/example/03_parse_tsv_from_memory.cpp
@@ -1,0 +1,25 @@
+/**
+ * Parses a TSV without header from null-terminated memory and print the contents.
+ */
+
+#include <PartialCsvParser.hpp>
+#include <vector>
+#include <string>
+#include <iostream>
+
+int main() {
+  const char * const tsv =
+    "Monday\tTuesday\tWednesday\tThursday\tFriday\tSaturday\tSunday\n"
+    "月曜\t火曜\t水曜\t木曜\t金曜\t土曜\t日曜\n";
+  PCP::Memory::CsvConfig csv_config(tsv, false, '\t');
+
+  // instantiate parser
+  PCP::PartialCsvParser parser(csv_config);
+
+  // parse & print favorite day of week
+  std::vector<std::string> row;
+  while (!(row = parser.get_row()).empty())
+    std::cout << row[5] << " is my favorite!" << std::endl;
+
+  return 0;
+}

--- a/test/integrated/PartialCsvParserWithOnMemoryCsvTest.cpp
+++ b/test/integrated/PartialCsvParserWithOnMemoryCsvTest.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+#include <PartialCsvParser.hpp>
+
+using namespace PCP;
+
+class PartialCsvParserWithOnMemoryCsvTest : public ::testing::Test {
+protected:
+  PartialCsvParserWithOnMemoryCsvTest() {}
+
+  virtual void SetUp() {}
+};
+
+TEST_F(PartialCsvParserWithOnMemoryCsvTest, NullTerminatedString) {
+  const char * const csv =
+    "101,102\n"
+    "201,202\n";
+
+  Memory::CsvConfig csv_config(csv, false);
+  PartialCsvParser parser(csv_config);
+
+  std::vector<std::string> row;
+
+  EXPECT_FALSE((row = parser.get_row()).empty());
+  EXPECT_EQ(2, row.size());
+  EXPECT_EQ("101", row[0]);
+  EXPECT_EQ("102", row[1]);
+
+  EXPECT_FALSE((row = parser.get_row()).empty());
+  EXPECT_EQ(2, row.size());
+  EXPECT_EQ("201", row[0]);
+  EXPECT_EQ("202", row[1]);
+
+  EXPECT_TRUE((row = parser.get_row()).empty());
+}
+
+TEST_F(PartialCsvParserWithOnMemoryCsvTest, StringWithLength) {
+  const char * const csv =
+    "101,102\n"
+    "201,202_this_should_be_ignored\n";
+
+  Memory::CsvConfig csv_config(15UL, csv, false);
+  PartialCsvParser parser(csv_config);
+
+  std::vector<std::string> row;
+
+  EXPECT_FALSE((row = parser.get_row()).empty());
+  EXPECT_EQ(2, row.size());
+  EXPECT_EQ("101", row[0]);
+  EXPECT_EQ("102", row[1]);
+
+  EXPECT_FALSE((row = parser.get_row()).empty());
+  EXPECT_EQ(2, row.size());
+  EXPECT_EQ("201", row[0]);
+  EXPECT_EQ("202", row[1]);
+
+  EXPECT_TRUE((row = parser.get_row()).empty());
+}


### PR DESCRIPTION
Adds `PCP::Memory::CsvConfig` to parse CSV directly from memory.

See example/03_parse_tsv_from_memory.cpp
